### PR TITLE
Rename newsletters, include an alias

### DIFF
--- a/content/2018-03-15-newsletter-1.md
+++ b/content/2018-03-15-newsletter-1.md
@@ -4,6 +4,7 @@ date = 2018-03-15
 draft = false
 in_search_index = true
 template = "page.html"
+aliases = ["2018-03-15/"]
 +++
 
 This is the first newsletter of the [Embedded WG]! We will be releasing this newsletter on a bi-weekly basis, and we are looking to highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!

--- a/content/2018-03-29-newsletter-2.md
+++ b/content/2018-03-29-newsletter-2.md
@@ -4,6 +4,7 @@ date = 2018-03-29
 draft = false
 in_search_index = true
 template = "page.html"
+aliases = ["2018-03-29/"]
 +++
 
 This is the second bi-weekly newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!

--- a/content/2018-04-14-newsletter-3.md
+++ b/content/2018-04-14-newsletter-3.md
@@ -4,6 +4,7 @@ date = 2018-04-14
 draft = false
 in_search_index = true
 template = "page.html"
+aliases = ["2018-04-14/"]
 +++
 
 This is the third bi-weekly newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!

--- a/content/2018-04-28-newsletter-4.md
+++ b/content/2018-04-28-newsletter-4.md
@@ -4,6 +4,7 @@ date = 2018-04-28
 draft = false
 in_search_index = true
 template = "page.html"
+aliases = ["2018-04-28/"]
 +++
 
 This is the fourth bi-weekly newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!

--- a/content/2018-05-15-newsletter-5.md
+++ b/content/2018-05-15-newsletter-5.md
@@ -4,6 +4,7 @@ date = 2018-05-15
 draft = false
 in_search_index = true
 template = "page.html"
+aliases = ["2018-05-15/"]
 +++
 
 This is the fifth bi-weekly newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!

--- a/content/2018-05-28-newsletter-6.md
+++ b/content/2018-05-28-newsletter-6.md
@@ -4,6 +4,7 @@ date = 2018-07-01
 draft = false
 in_search_index = true
 template = "page.html"
+aliases = ["2018-07-01/"]
 +++
 
 This is the sixth newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!

--- a/content/2018-07-15-newsletter-7.md
+++ b/content/2018-07-15-newsletter-7.md
@@ -4,6 +4,7 @@ date = 2018-07-15
 draft = false
 in_search_index = true
 template = "page.html"
+aliases = ["2018-07-15/"]
 +++
 
 This is the seventh newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!

--- a/content/2018-07-29-newsletter-8.md
+++ b/content/2018-07-29-newsletter-8.md
@@ -4,6 +4,7 @@ date = 2018-07-29
 draft = false
 in_search_index = true
 template = "page.html"
+aliases = ["2018-07-29/"]
 +++
 
 This is the eighth newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!

--- a/content/2018-08-12-newsletter-9.md
+++ b/content/2018-08-12-newsletter-9.md
@@ -4,6 +4,7 @@ date = 2018-08-12
 draft = false
 in_search_index = true
 template = "page.html"
+aliases = ["2018-08-12/"]
 +++
 
 This is the ninth newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!


### PR DESCRIPTION
Alias still keeps the page there (in case of existing links), but changes the canonical URL