### PR TITLE
Fill in social media links for post 11

### DIFF
--- a/content/2018-09-09-newsletter-11.md
+++ b/content/2018-09-09-newsletter-11.md
@@ -25,7 +25,7 @@ If you want to mention something in [the next newsletter], make sure to leave a 
 ## Highlights
 
 * `rustc` now supports 4 **Cortex-R** targets thanks to the work of [paoloteti] in the Cortex-R space! You can build programs for these targets using nothing but the Rust toolchain
-* [James Munns] gave a talk at RustConf 2018, covering the basics of embedded systems, and how Rust's Zero Cost Abstractions are a perfect match for bare metal systems
+* [James Munns] gave a talk [at RustConf 2018], covering the basics of embedded systems, and how Rust's Zero Cost Abstractions are a perfect match for bare metal systems
 
 [paoloteti]: https://github.com/paoloteti
 

--- a/content/2018-09-09-newsletter-11.md
+++ b/content/2018-09-09-newsletter-11.md
@@ -12,10 +12,9 @@ This is the eleventh newsletter of the [Embedded WG] where we highlight new prog
 
 Discuss on [internals.rust-lang.org], [on twitter], or [on reddit]!
 
-<!-- TODO, update links after post lands -->
-[internals.rust-lang.org]: #
-[on twitter]: #
-[on reddit]: #
+[internals.rust-lang.org]: https://internals.rust-lang.org/t/the-embedded-working-group-newsletter-11/8377
+[on twitter]: https://twitter.com/rustembedded/status/1039055481946492928
+[on reddit]: https://www.reddit.com/r/rust/comments/9eku70/rust_embedded_working_group_newsletter_11_cortexr/
 
 <!-- more -->
 


### PR DESCRIPTION
Fixing links (and indirectly, the broken render) for social media.

Note to future self: Gutenberg doesn't like "null" links.