### PR TITLE
Newsletter 18: fix 'read more' cutoff

### DIFF
--- a/content/2019-07-02-newsletter-18.md
+++ b/content/2019-07-02-newsletter-18.md
@@ -18,6 +18,8 @@ This is the eighteenth newsletter of the [Embedded WG] where we highlight new pr
 <!-- [on twitter]: https://example.org/#TODO -->
 <!-- [on reddit]: https://example.org/#TODO -->
 
+<!-- more -->
+
 <!-- If you want to mention something in [the next newsletter], send us a pull request! -->
 
 <!-- [the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/${TODO}.md -->


### PR DESCRIPTION
I seem to have accidentally nuked this marker while I was preparing newsletter 18 for release; this adds it back in, so that the intro blurb on the blog index looks right :)