### PR TITLE
Add RSS Feed to navigation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,4 +26,5 @@ hyde_links = [
     {url = "https://rust-lang.org", name = "The Rust Language"},
     {url = "https://github.com/rust-embedded/wg", name = "Embedded WG"},
     {url = "https://github.com/rust-embedded/blog", name = "The Blog on GitHub"},
+    {url = "https://rust-embedded.github.io/blog/rss.xml", name = "RSS Feed"},
 ]


### PR DESCRIPTION
We often get questions regarding the RSS feed, this adds a link to the top navigation so people can find it easier