### PR TITLE
Make the RSS-feed fulltext

### DIFF
--- a/themes/hyde/templates/rss.xml
+++ b/themes/hyde/templates/rss.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+        <title>{{ config.title }}</title>
+        <link>{{ config.base_url | escape_xml | safe }}</link>
+        <description>{{ config.description }}</description>
+        <generator>Zola</generator>
+        <language>{{ config.default_language }}</language>
+        <atom:link href="{{ feed_url | safe }}" rel="self" type="application/rss+xml"/>
+        <lastBuildDate>{{ last_build_date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
+        {% for page in pages %}
+            <item>
+                <title>{{ page.title }}</title>
+                <pubDate>{{ page.date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
+                <link>{{ page.permalink | escape_xml | safe }}</link>
+                <guid>{{ page.permalink | escape_xml | safe }}</guid>
+                <description>{{ page.content }}</description>
+            </item>
+        {% endfor %}
+    </channel>
+</rss>


### PR DESCRIPTION
This copies the [default rss template from zola](https://github.com/getzola/zola/blob/master/components/templates/src/builtins/rss.xml) and changes the `<description>` tag of all pages from `page.summary` to `page.content` to show the whole article in rss readers and not only the summary (which, in case of the newsletter, only explains the concept of the newsletter and shows links to the discussion, but does not summarize this specific newsletter itself, which I find pretty useless). For comparison, This Week in Rust also puts the fulltext articles in the rss-feed.

I have tried the change locally and it does generate the intended `rss.xml`,
but I didn't check if it also renders as nice as intended (But I'm pretty sure it will, I'll test this soon.)

I'm also not sure how smooth the transition between these two rss feeds has to be.