### PR TITLE
Add support for twitter cards (root page and blogposts)

### DIFF
--- a/themes/hyde/templates/index.html
+++ b/themes/hyde/templates/index.html
@@ -7,6 +7,15 @@
       <!-- Enable responsiveness on mobile devices-->
       <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
+      <!-- Twitter Card Support -->
+      {% block twitter_meta %}
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:site" content="@rustembedded" />
+        <meta name="twitter:title" content="Rust Embedded" />
+        <meta name="twitter:description" content="The Rust Embedded Working Group" />
+        <meta name="twitter:image" content="{{ get_url(path="ewg-logo-blue-white-on-transparent.svg", trailing_slash=false) }}" />
+      {%endblock twitter_meta %}
+
       <title>{% block title %}{{ config.title }}{% endblock title %}</title>
 
       <!-- CSS -->

--- a/themes/hyde/templates/page.html
+++ b/themes/hyde/templates/page.html
@@ -1,5 +1,14 @@
 {% extends "index.html" %}
 
+<!-- Twitter Card Support - Blog Post Override -->
+{% block twitter_meta %}
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:site" content="@rustembedded" />
+  <meta name="twitter:title" content="{{ page.title }}" />
+  <meta name="twitter:description" content="{{ page.summary | safe }}" />
+  <meta name="twitter:image" content="{{ get_url(path="ewg-logo-blue-white-on-transparent.svg", trailing_slash=false) }}" />
+{%endblock twitter_meta %}
+
 {% block content %}
 <div class="post">
   <h1 class="post-title">{{ page.title }}</h1>


### PR DESCRIPTION
Adds a default implementation of the twitter card format to the general index page, as well as a specialization for blog posts that uses the title and summary of the blogpost.

Closes #67 