### PR TITLE
Fix rss template

### DIFF
--- a/templates/rss.xml
+++ b/templates/rss.xml
@@ -2,7 +2,7 @@
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
         <title>{{ config.title }}</title>
-        <link>{{ config.base_url | escape_xml | safe }}</link>
+        <link>{{ config.base_url | safe }}</link>
         <description>{{ config.description }}</description>
         <generator>Zola</generator>
         <language>{{ config.default_language }}</language>
@@ -12,8 +12,8 @@
             <item>
                 <title>{{ page.title }}</title>
                 <pubDate>{{ page.date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
-                <link>{{ page.permalink | escape_xml | safe }}</link>
-                <guid>{{ page.permalink | escape_xml | safe }}</guid>
+                <link>{{ page.permalink | safe }}</link>
+                <guid>{{ page.permalink | safe }}</guid>
                 <description>{{ page.content }}</description>
             </item>
         {% endfor %}


### PR DESCRIPTION
This commit fixes the rss fulltext template introduced in #75 which was originally build under the assumption of zola v0.9.0.
For v0.5.1 the template has to be in a different location and can't use `escape_xml` as that was introduced in later versions.
This should do no harm because the links didn't contain xml in the first place.