### PR TITLE
Add VEML6030 ambient light sensor

### DIFF
--- a/content/2019-12-26-newsletter-22.md
+++ b/content/2019-12-26-newsletter-22.md
@@ -45,6 +45,8 @@ If you want to mention something in [the next newsletter], send us a pull reques
 
 - [@eldruin] released a platform-agnostic [driver for the PCA9685][pca9685-driver] PWM LED/Servo controller driver and published a [blog post][pca9685-blog-post] including a video of the device controlling RGB LEDs and several Servo motors simultaneously.
 
+- [@eldruin] released a platform-agnostic [driver for Vishay's VEML6030][veml6030-driver] ambient light sensor and published a [blog post][veml6030-blog-post] including pictures of the device in a PCB of a commercial product where the application is written in Rust.
+
 - [@nickray] released `salty` ([API][salty-api], [book][salty-book], [code][salty-code]), a library for fast Ed25519 signatures on Cortex-M4 and Cortex-M33 microcontrollers. It presents the `ed25519-dalek` API, but is self-contained and uses the fastest currently published field operations implementation, due to Bjoern Haase, based on the `UMAAL` DSP instruction `(a: u32, b: u32, c: u32, d: u32) -> (a * b + c + d): u64`. Testing is done on the `musca-b1` Cortex-M33 microcontroller, simulated in QEMU v4. Additionally, a C API is included.
 
 - [@nickray] released `littlefs2` ([API][littlefs2-api], [code][littlefs2-code]), an idiomatic Rust API for the [`littlefs`][littlefs-upstream] filesystem for microcontrollers, modeled after `std::fs`. The upstream library claims to be resilient against power-loss, and supports features like dynamic wear-leveling with bad block detection, inline files for efficient use of storage, and custom user attributes on files and directories.
@@ -58,6 +60,9 @@ If you want to mention something in [the next newsletter], send us a pull reques
 
 [pca9685-driver]: https://crates.io/crates/pwm-pca9685
 [pca9685-blog-post]: https://blog.eldruin.com/pca9685-pwm-led-servo-controller-driver-in-rust/
+
+[veml6030-driver]: https://crates.io/crates/veml6030
+[veml6030-blog-post]: https://blog.eldruin.com/veml6030-ambient-light-sensor-driver-in-rust/
 
 [@nickray]: https://github.com/nickray
 [salty-api]: https://api.salty.rs

--- a/content/2019-12-26-newsletter-22.md
+++ b/content/2019-12-26-newsletter-22.md
@@ -45,7 +45,7 @@ If you want to mention something in [the next newsletter], send us a pull reques
 
 - [@eldruin] released a platform-agnostic [driver for the PCA9685][pca9685-driver] PWM LED/Servo controller driver and published a [blog post][pca9685-blog-post] including a video of the device controlling RGB LEDs and several Servo motors simultaneously.
 
-- [@eldruin] released a platform-agnostic [driver for Vishay's VEML6030][veml6030-driver] ambient light sensor and published a [blog post][veml6030-blog-post] including pictures of the device in a PCB of a commercial product where the application is written in Rust.
+- [@eldruin] released a platform-agnostic [driver for Vishay's VEML6030][veml6030-driver] ambient light sensor and published a [blog post][veml6030-blog-post].
 
 - [@nickray] released `salty` ([API][salty-api], [book][salty-book], [code][salty-code]), a library for fast Ed25519 signatures on Cortex-M4 and Cortex-M33 microcontrollers. It presents the `ed25519-dalek` API, but is self-contained and uses the fastest currently published field operations implementation, due to Bjoern Haase, based on the `UMAAL` DSP instruction `(a: u32, b: u32, c: u32, d: u32) -> (a * b + c + d): u64`. Testing is done on the `musca-b1` Cortex-M33 microcontroller, simulated in QEMU v4. Additionally, a C API is included.
 


### PR DESCRIPTION
I just released this driver. I added the link together with my other two links for grouping reasons but it is also fine for me to put it after Nick Ray's links.
Please let me know if you think it would be better to change the order.