### PR TITLE
Add embedded-graphics 0.7.0-beta.1 release

### DIFF
--- a/content/2021-04-16-newsletter-28.md
+++ b/content/2021-04-16-newsletter-28.md
@@ -62,6 +62,8 @@ go here include:
 If you have an embedded project or blog post you would like to have featured in the Embedded WG Newsletter, make sure to add it to [the next newsletter], we would love to show it off!
 
 - TODO(remove, this is an example) Crate embedded-foo has released version 1.0.0!
+- [embedded-graphics 0.7.0-beta.1 released] as the first stable step towards the long awaited 0.7.0! 
+  There should be no major/breaking changes after this release as we work mostly on documentation, bugfixes and polish. See the release notes [here](https://github.com/embedded-graphics/embedded-graphics/releases/tag/embedded-graphics-v0.7.0-beta.1).
 
 <!-- LINK SECTION FOR HIGHLIGHTS AND EMBEDDED PROJECTS -->
 
@@ -78,6 +80,7 @@ you would like for yourself.
 TODO: Put all links for content here.
 -->
 [embedded-foo 1.0.0 released]: https://example.com/blog/...
+[embedded-graphics 0.7.0-beta.1 released]: https://crates.io/crates/embedded-graphics/0.7.0-beta.1
 
 ## `embedded-hal` Ecosystem Crates
 


### PR DESCRIPTION
[embedded-graphics](https://crates.io/crates/embedded-graphics) just had its first, very long awaited 0.7.0 beta release.