### PR TITLE
Use a static link of content/newsletter-next.md for the next newsletter.

### DIFF
--- a/newsletter-template.md
+++ b/newsletter-template.md
@@ -25,9 +25,7 @@ This is the ${TODO}th newsletter of the [Embedded WG] where we highlight new pro
 
 If you want to mention something in [the next newsletter], send us a pull request!
 
-<!-- TODO before release add the next template! -->
-
-[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/${TODO}.md
+[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/newsletter-next.md
 
 ## Highlights
 


### PR DESCRIPTION
This allows us to not worry too much about publication dates beforehand
and also no matter which newsletter people are looking at, there'll be
always a valid link to go to submit new content.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>