### PR TITLE
move highlights above fold and get involved to bottom

### DIFF
--- a/content/2021-02-16-newsletter-26.md
+++ b/content/2021-02-16-newsletter-26.md
@@ -6,20 +6,6 @@ in_search_index = true
 template = "page.html"
 +++
 
-This is the 26th newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
-
-[Embedded WG]: https://github.com/rust-embedded/wg
-
-Discuss on [#rust-embedded:matrix.org]!
-
-[#rust-embedded:matrix.org]: https://matrix.to/#/#rust-embedded:matrix.org
-
-<!-- more -->
-
-If you want to mention something in [the next newsletter], send us a pull request!
-
-[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/2021-03-16-newsletter-27.md
-
 ## Highlights
 
 - [@cecton] wrote a blog post targeted to experienced developers but embedded development beginners: [Rust, Arduino and Embedded Development as a Beginner: Part 1]
@@ -34,6 +20,8 @@ If you want to mention something in [the next newsletter], send us a pull reques
 - The Rust Embedded Working Group's MSRV (Minimum Supported Rust Version)
   policy has been updated and now only requires that crates build on the
   latest stable Rust release. See [msrv] for more details.
+
+<!-- more -->
 
 ## Embedded Projects
 
@@ -71,3 +59,17 @@ If you have an embedded project or blog post you would like to have featured in 
 [msrv]: https://github.com/rust-embedded/wg/pull/523
 
 [debouncr]: https://docs.rs/debouncr/
+
+## Get Involved
+
+This is the 26th newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
+
+[Embedded WG]: https://github.com/rust-embedded/wg
+
+Discuss on [#rust-embedded:matrix.org]!
+
+[#rust-embedded:matrix.org]: https://matrix.to/#/#rust-embedded:matrix.org
+
+If you want to mention something in [the next newsletter], send us a pull request!
+
+[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/2021-03-16-newsletter-27.md

--- a/content/2021-03-16-newsletter-27.md
+++ b/content/2021-03-16-newsletter-27.md
@@ -6,27 +6,6 @@ in_search_index = true
 template = "page.html"
 +++
 
-This is the 27th newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
-
-[Embedded WG]: https://github.com/rust-embedded/wg
-
-<!-- TODO uncomment -->
-
-<!-- Discuss on [#rust-embedded:matrix.org], [users.rust-lang.org], [on twitter], or [on reddit]! -->
-
-<!-- [#rust-embedded:matrix.org]: https://matrix.to/#/#rust-embedded:matrix.org -->
-<!-- [users.rust-lang.org]: https://example.org/#TODO -->
-<!-- [on twitter]: https://example.org/#TODO -->
-<!-- [on reddit]: https://example.org/#TODO -->
-
-<!-- more -->
-
-If you want to mention something in [the next newsletter], send us a pull request!
-
-<!-- TODO before release add the next template! -->
-
-[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/2021-04-16-newsletter-28.md
-
 ## Highlights
 
 - [@hannobraun](https://github.com/hannobraun) published [Last Month in Flott - March 2021](https://flott-motion.org/news/last-month-in-flott-march-2021/), the monthly newsletter for Flott. Flott is an open source toolkit for motion control software in Rust (designed to run everywhere, including microcontrollers).
@@ -47,6 +26,8 @@ If you want to mention something in [the next newsletter], send us a pull reques
 
 [#rust-embedded:matrix.org]: https://matrix.to/#/#rust-embedded:matrix.org
 
+<!-- more -->
+
 ## Embedded Projects
 
 If you have an embedded project or blog post you would like to have featured in the Embedded WG Newsletter, make sure to add it to [the next newsletter], we would love to show it off!
@@ -62,3 +43,24 @@ As part of the [Weekly Driver Initiative], crates that are part of the `embedded
 
 [Awesome Embedded Rust]: https://github.com/rust-embedded/awesome-embedded-rust
 [Weekly Driver Initiative]: https://github.com/rust-embedded/wg/issues/39
+
+## Get Involved
+
+This is the 27th newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
+
+[Embedded WG]: https://github.com/rust-embedded/wg
+
+<!-- TODO uncomment -->
+
+<!-- Discuss on [#rust-embedded:matrix.org], [users.rust-lang.org], [on twitter], or [on reddit]! -->
+
+<!-- [#rust-embedded:matrix.org]: https://matrix.to/#/#rust-embedded:matrix.org -->
+<!-- [users.rust-lang.org]: https://example.org/#TODO -->
+<!-- [on twitter]: https://example.org/#TODO -->
+<!-- [on reddit]: https://example.org/#TODO -->
+
+If you want to mention something in [the next newsletter], send us a pull request!
+
+<!-- TODO before release add the next template! -->
+
+[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/2021-04-16-newsletter-28.md

--- a/content/2021-04-20-newsletter-28.md
+++ b/content/2021-04-20-newsletter-28.md
@@ -6,25 +6,11 @@ in_search_index = true
 template = "page.html"
 +++
 
-This is the 28th newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
-
-[Embedded WG]: https://github.com/rust-embedded/wg
-
-Discuss on [#rust-embedded:matrix.org]!
-
-[#rust-embedded:matrix.org]: https://matrix.to/#/#rust-embedded:matrix.org
-
-<!-- more -->
-
-If you want to mention something in [the next newsletter], send us a pull request!
-
-<!-- TODO before release add the next template! -->
-
-[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/2021-05-07-newsletter-29.md
-
 ## Highlights
 
 - [Last Month in Flott](https://flott-motion.org/news/last-month-in-flott-april-2021/), the monthly newsletter for Flott has been published. Flott is an open source toolkit for motion control software in Rust (designed to run everywhere, including microcontrollers).
+
+<!-- more -->
 
 ## Embedded Projects
 
@@ -53,3 +39,19 @@ As part of the [Weekly Driver Initiative], crates that are part of the `embedded
 
 [Awesome Embedded Rust]: https://github.com/rust-embedded/awesome-embedded-rust
 [Weekly Driver Initiative]: https://github.com/rust-embedded/wg/issues/39
+
+## Get Involved
+
+This is the 28th newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
+
+[Embedded WG]: https://github.com/rust-embedded/wg
+
+Discuss on [#rust-embedded:matrix.org]!
+
+[#rust-embedded:matrix.org]: https://matrix.to/#/#rust-embedded:matrix.org
+
+If you want to mention something in [the next newsletter], send us a pull request!
+
+<!-- TODO before release add the next template! -->
+
+[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/2021-05-07-newsletter-29.md

--- a/content/2021-07-27-newsletter-29.md
+++ b/content/2021-07-27-newsletter-29.md
@@ -6,16 +6,6 @@ in_search_index = true
 template = "page.html"
 +++
 
-This is the 29th newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
-
-[Embedded WG]: https://github.com/rust-embedded/wg
-
-<!-- more -->
-
-If you want to mention something in [the next newsletter], send us a pull request!
-
-[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/2021-08-24-newsletter-30.md
-
 ## Highlights
 
 - [Last Month in Flott](https://flott-motion.org/news/last-month-in-flott-may-2021/), the monthly newsletter for Flott has been published. Flott is an open source toolkit for motion control software in Rust (designed to run everywhere, including microcontrollers).
@@ -26,6 +16,8 @@ If you want to mention something in [the next newsletter], send us a pull reques
 - [cortex-m](https://crates.io/crates/cortex-m) released version 0.7.3, improving ease-of-use for the `Delay` implementation and fixing native builds on non-x86 hosts.
 - [cortex-m-rt](https://crates.io/crates/cortex-m-rt) released version 0.6.15, backporting various fixes to the linker script and helping prepare for a new 0.7 release soon.
 - [cross](https://github.com/rust-embedded/cross) has posted a [call for help](https://github.com/rust-embedded/cross/issues/574) looking for new maintainers: if you use cross and would like to help out, please check it out!
+
+<!-- more -->
 
 ## Embedded Projects
 
@@ -42,3 +34,13 @@ As part of the [Weekly Driver Initiative], crates that are part of the `embedded
 
 [Awesome Embedded Rust]: https://github.com/rust-embedded/awesome-embedded-rust
 [Weekly Driver Initiative]: https://github.com/rust-embedded/wg/issues/39
+
+This is the 29th newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
+
+[Embedded WG]: https://github.com/rust-embedded/wg
+
+## Get Involved
+
+If you want to mention something in [the next newsletter], send us a pull request!
+
+[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/2021-08-24-newsletter-30.md

--- a/content/2021-11-16-newsletter-30.md
+++ b/content/2021-11-16-newsletter-30.md
@@ -8,26 +8,14 @@ template = "page.html"
 
 <!-- TODO before release set `draft` to `false` and `in_search_index` to `true` -->
 
-This is the 30th newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
-
-[Embedded WG]: https://github.com/rust-embedded/wg
-
-Discuss on [#rust-embedded:matrix.org]!
-
-[#rust-embedded:matrix.org]: https://matrix.to/#/#rust-embedded:matrix.org
-
-<!-- more -->
-
-If you want to mention something in [the next newsletter], send us a pull request!
-
-[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/newsletter-next.md
-
 ## Highlights
 
 - [@dkhayes117] joined the embedded working group's RISC-V team
 - Rust std support added for the ESP32: https://github.com/rust-lang/rust/pull/87666
 - [Rust on Espressif chips update](https://mabez.dev/blog/posts/esp-rust-18-10-2021/)
 - [State of LoRaWAN support](https://blog.drogue.io/lorawan-update/)
+
+<!-- more -->
 
 ## Embedded Projects
 
@@ -67,3 +55,17 @@ As part of the [Weekly Driver Initiative], crates that are part of the `embedded
 
 [Awesome Embedded Rust]: https://github.com/rust-embedded/awesome-embedded-rust
 [Weekly Driver Initiative]: https://github.com/rust-embedded/wg/issues/39
+
+## Get Involved
+
+This [Embedded WG] blog is where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
+
+[Embedded WG]: https://github.com/rust-embedded/wg
+
+Discuss on [#rust-embedded:matrix.org]!
+
+[#rust-embedded:matrix.org]: https://matrix.to/#/#rust-embedded:matrix.org
+
+If you want to mention something in [the next newsletter], send us a pull request!
+
+[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/newsletter-next.md

--- a/content/newsletter-next.md
+++ b/content/newsletter-next.md
@@ -8,25 +8,6 @@ template = "page.html"
 
 <!-- TODO before release set `draft` to `false` and `in_search_index` to `true` -->
 
-This is the 31th newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
-
-[Embedded WG]: https://github.com/rust-embedded/wg
-
-<!-- TODO uncomment -->
-
-<!-- Discuss on [#rust-embedded:matrix.org], [users.rust-lang.org], [on twitter], or [on reddit]! -->
-
-<!-- [#rust-embedded:matrix.org]: https://matrix.to/#/#rust-embedded:matrix.org -->
-<!-- [users.rust-lang.org]: https://example.org/#TODO -->
-<!-- [on twitter]: https://example.org/#TODO -->
-<!-- [on reddit]: https://example.org/#TODO -->
-
-<!-- more -->
-
-If you want to mention something in [the next newsletter], send us a pull request!
-
-[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/newsletter-next.md
-
 ## Highlights
 
 <!--
@@ -41,6 +22,8 @@ TODO Add news related to embedded Rust that are not about new crates releases he
 - TODO(remove, this is an example) "const generics" has landed in nightly!
 
 - TODO(remove, this is an example) the Rust compiler has gained cross compilation support for the Xtensa architecture!
+
+<!-- more -->
 
 ## Embedded Projects
 
@@ -82,3 +65,22 @@ As part of the [Weekly Driver Initiative], crates that are part of the `embedded
 
 [Awesome Embedded Rust]: https://github.com/rust-embedded/awesome-embedded-rust
 [Weekly Driver Initiative]: https://github.com/rust-embedded/wg/issues/39
+
+## Get Involved
+
+This [Embedded WG] blog is where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
+
+[Embedded WG]: https://github.com/rust-embedded/wg
+
+<!-- TODO uncomment -->
+
+<!-- Discuss on [#rust-embedded:matrix.org], [users.rust-lang.org], [on twitter], or [on reddit]! -->
+
+<!-- [#rust-embedded:matrix.org]: https://matrix.to/#/#rust-embedded:matrix.org -->
+<!-- [users.rust-lang.org]: https://example.org/#TODO -->
+<!-- [on twitter]: https://example.org/#TODO -->
+<!-- [on reddit]: https://example.org/#TODO -->
+
+If you want to mention something in [the next newsletter], send us a pull request!
+
+[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/newsletter-next.md

--- a/newsletter-template.md
+++ b/newsletter-template.md
@@ -8,25 +8,6 @@ template = "page.html"
 
 <!-- TODO before release set `draft` to `false` and `in_search_index` to `true` -->
 
-This is the ${TODO}th newsletter of the [Embedded WG] where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
-
-[Embedded WG]: https://github.com/rust-embedded/wg
-
-<!-- TODO uncomment -->
-
-<!-- Discuss on [#rust-embedded:matrix.org], [users.rust-lang.org], [on twitter], or [on reddit]! -->
-
-<!-- [#rust-embedded:matrix.org]: https://matrix.to/#/#rust-embedded:matrix.org -->
-<!-- [users.rust-lang.org]: https://example.org/#TODO -->
-<!-- [on twitter]: https://example.org/#TODO -->
-<!-- [on reddit]: https://example.org/#TODO -->
-
-<!-- more -->
-
-If you want to mention something in [the next newsletter], send us a pull request!
-
-[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/newsletter-next.md
-
 ## Highlights
 
 <!--
@@ -41,6 +22,8 @@ TODO Add news related to embedded Rust that are not about new crates releases he
 - TODO(remove, this is an example) "const generics" has landed in nightly!
 
 - TODO(remove, this is an example) the Rust compiler has gained cross compilation support for the Xtensa architecture!
+
+<!-- more -->
 
 ## Embedded Projects
 
@@ -79,3 +62,22 @@ As part of the [Weekly Driver Initiative], crates that are part of the `embedded
 
 [Awesome Embedded Rust]: https://github.com/rust-embedded/awesome-embedded-rust
 [Weekly Driver Initiative]: https://github.com/rust-embedded/wg/issues/39
+
+## Get Involved
+
+This [Embedded WG] blog is where we highlight new progress, celebrate cool projects, thank the community, and advertise projects that need help!
+
+[Embedded WG]: https://github.com/rust-embedded/wg
+
+<!-- TODO uncomment -->
+
+<!-- Discuss on [#rust-embedded:matrix.org], [users.rust-lang.org], [on twitter], or [on reddit]! -->
+
+<!-- [#rust-embedded:matrix.org]: https://matrix.to/#/#rust-embedded:matrix.org -->
+<!-- [users.rust-lang.org]: https://example.org/#TODO -->
+<!-- [on twitter]: https://example.org/#TODO -->
+<!-- [on reddit]: https://example.org/#TODO -->
+
+If you want to mention something in [the next newsletter], send us a pull request!
+
+[the next newsletter]: https://github.com/rust-embedded/blog/edit/master/content/newsletter-next.md


### PR DESCRIPTION
As discussed in chat, the current blog shows boilerplate for each newsletter. Instead move highlights up and the top section, which Im now calling Get Involved to the bottom.

I did this for the template, next newsletter, as well as back to 26 so that the front page of the site now looks more like a blog.

