### PR TITLE
added VA108xx support

### DIFF
--- a/content/newsletter-next.md
+++ b/content/newsletter-next.md
@@ -50,6 +50,8 @@ If you have an embedded project or blog post you would like to have featured in 
     [va108xx-hal](https://egit.irs.uni-stuttgart.de/rust/va108xx-hal) HAL
     and [vorago-reb1](https://egit.irs.uni-stuttgart.de/rust/vorago-reb1) BSP
     with [blogpost](https://robamu.github.io/post/rust-ecosystem/)
+- New [device driver crate](https://egit.irs.uni-stuttgart.de/rust/max116xx-10bit) for the MAX116xx
+    10-bit ADC devices
 <!-- LINK SECTION FOR HIGHLIGHTS AND EMBEDDED PROJECTS -->
 
 <!--

--- a/content/newsletter-next.md
+++ b/content/newsletter-next.md
@@ -51,7 +51,7 @@ If you have an embedded project or blog post you would like to have featured in 
     and [vorago-reb1](https://egit.irs.uni-stuttgart.de/rust/vorago-reb1) BSP
     with [blogpost](https://robamu.github.io/post/rust-ecosystem/)
 - New [device driver crate](https://egit.irs.uni-stuttgart.de/rust/max116xx-10bit) for the MAX116xx
-    10-bit ADC devices
+    10-bit ADC devices with [blogpost](https://robamu.github.io/post/max11619-driver-rust/)
 <!-- LINK SECTION FOR HIGHLIGHTS AND EMBEDDED PROJECTS -->
 
 <!--

--- a/content/newsletter-next.md
+++ b/content/newsletter-next.md
@@ -45,7 +45,11 @@ If you have an embedded project or blog post you would like to have featured in 
 - [embedded-hal] 1.0.0-alpha.6 released, with a number of new features and
     changes as we work towards the final 1.0 release. Most notably,
     CAN (Controller Area Network) traits were added.
-
+- New Rust Embedded ecosystem for the Vorago VA108xx family of devices:
+    [va108xx](https://egit.irs.uni-stuttgart.de/rust/va108xx) PAC,
+    [va108xx-hal](https://egit.irs.uni-stuttgart.de/rust/va108xx-hal) HAL
+    and [vorago-reb1](https://egit.irs.uni-stuttgart.de/rust/vorago-reb1) BSP
+    with [blogpost](https://robamu.github.io/post/rust-ecosystem/)
 <!-- LINK SECTION FOR HIGHLIGHTS AND EMBEDDED PROJECTS -->
 
 <!--

--- a/content/newsletter-next.md
+++ b/content/newsletter-next.md
@@ -45,7 +45,7 @@ If you have an embedded project or blog post you would like to have featured in 
 - [embedded-hal] 1.0.0-alpha.6 released, with a number of new features and
     changes as we work towards the final 1.0 release. Most notably,
     CAN (Controller Area Network) traits were added.
-- New Rust Embedded ecosystem for the Vorago VA108xx family of devices:
+- New Rust Embedded ecosystem for the radiation-hardened Vorago VA108xx family of devices:
     [va108xx](https://egit.irs.uni-stuttgart.de/rust/va108xx) PAC,
     [va108xx-hal](https://egit.irs.uni-stuttgart.de/rust/va108xx-hal) HAL
     and [vorago-reb1](https://egit.irs.uni-stuttgart.de/rust/vorago-reb1) BSP


### PR DESCRIPTION
As suggested in https://github.com/rust-embedded/awesome-embedded-rust/pull/351 .
I can also add the new device driver crate (max116xx 10-bit) but I think this is already covered by https://github.com/rust-embedded/awesome-embedded-rust/pull/351